### PR TITLE
refactor: add context-support and rename package

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
-	httpsclient "github.com/infraspecdev/goperf/internal/httpclient"
+	"github.com/infraspecdev/goperf/internal/httpclient"
 	"github.com/spf13/cobra"
 )
 
@@ -54,15 +56,19 @@ var runCmd = &cobra.Command{
 
 		fmt.Println("Parsed URL:", u)
 		fmt.Printf("Making %d requests to %s\n", requests, u)
+
 		if requests > 1 {
-           return runCommandMultiple(args[0], requests, cmd.OutOrStdout())
-       }
+			return runCommandMultiple(args[0], requests, cmd.OutOrStdout())
+		}
 		return runCommand(args[0], cmd.OutOrStdout())
 	},
 }
 
-func runCommand(url string, out io.Writer) error {
-	statusCode, duration, err := httpsclient.MakeRequest(url)
+func runCommand(target string, out io.Writer) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	statusCode, duration, err := httpclient.MakeRequest(ctx, target)
 	if err != nil {
 		return err
 	}
@@ -75,19 +81,22 @@ func runCommand(url string, out io.Writer) error {
 	return nil
 }
 
-func runCommandMultiple(url string, n int, out io.Writer) error {
-   results := httpsclient.RunMultiple(nil, url, n)
-   for _, res := range results {
-       if res.Error != nil {
-           return res.Error
-       }
-       statusText := http.StatusText(res.StatusCode)
-       fmt.Fprintf(out, "Status: %d %s\n", res.StatusCode, statusText)
-       fmt.Fprintf(out, "Time: %dms\n", res.Duration.Milliseconds())
-   }
-   return nil
-}
+func runCommandMultiple(target string, n int, out io.Writer) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
+	results := httpclient.RunMultiple(ctx, target, n)
+
+	for _, res := range results {
+		if res.Error != nil {
+			return res.Error
+		}
+		statusText := http.StatusText(res.StatusCode)
+		fmt.Fprintf(out, "Status: %d %s\n", res.StatusCode, statusText)
+		fmt.Fprintf(out, "Time: %dms\n", res.Duration.Milliseconds())
+	}
+	return nil
+}
 
 func init() {
 	runCmd.Flags().IntP("requests", "n", 1, "Number of requests to execute")

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -15,12 +15,20 @@ type RequestResult struct {
 	Error      error
 }
 
-func MakeRequest(url string) (statusCode int, duration time.Duration, err error) {
+var client = &http.Client{
+	Timeout: 10 * time.Second,
+}
+
+func MakeRequest(ctx context.Context,url string) (statusCode int, duration time.Duration, err error) {
 
 	start := time.Now()
 
-	resp, err := http.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, 0, err
+	}
 
+	resp, err := client.Do(req)
 	duration = time.Since(start)
 
 	if err != nil {
@@ -50,7 +58,7 @@ func MakeRequest(url string) (statusCode int, duration time.Duration, err error)
 func RunMultiple(ctx context.Context, url string, n int) []RequestResult {
 	results := make([]RequestResult, n)
 	for i := 0; i < n; i++ {
-		statusCode, duration, err := MakeRequest(url)
+		statusCode, duration, err := MakeRequest(ctx,url)
 		results[i] = RequestResult{
 			StatusCode: statusCode,
 			Duration:   duration,

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -15,7 +15,7 @@ func TestMakeRequestSuccess(t *testing.T) {
 	}))
 	defer server.Close()
 
-	status, duration, err := MakeRequest(server.URL)
+	status, duration, err := MakeRequest(context.Background(), server.URL)
 
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -31,8 +31,7 @@ func TestMakeRequestSuccess(t *testing.T) {
 }
 
 func TestMakeRequestConnectionRefused(t *testing.T) {
-	// No server running on this port → connection refused
-	_, _, err := MakeRequest("http://127.0.0.1:9999")
+	_, _, err := MakeRequest(context.Background(), "http://127.0.0.1:9999")
 
 	if err == nil {
 		t.Fatalf("expected error, got nil")
@@ -44,7 +43,7 @@ func TestMakeRequestConnectionRefused(t *testing.T) {
 }
 
 func TestMakeRequestNoSuchHost(t *testing.T) {
-	_, _, err := MakeRequest("http://this-host-does-not-exist-12345")
+	_, _, err := MakeRequest(context.Background(), "http://this-host-does-not-exist-12345")
 
 	if err == nil {
 		t.Fatalf("expected error, got nil")
@@ -56,15 +55,16 @@ func TestMakeRequestNoSuchHost(t *testing.T) {
 	}
 }
 
-
 func TestRunMultipleExecutesNTimes(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
+
 	results := RunMultiple(context.Background(), server.URL, 3)
+
 	if len(results) != 3 {
-		t.Fatalf("Expected 3 results, got %d", len(results))
+		t.Fatalf("expected 3 results, got %d", len(results))
 	}
 }
 
@@ -75,9 +75,10 @@ func TestRunMultipleCollectsResults(t *testing.T) {
 	defer server.Close()
 
 	results := RunMultiple(context.Background(), server.URL, 2)
+
 	for i, result := range results {
 		if result.StatusCode != http.StatusOK {
-			t.Errorf("Result %d: expected status 200", i)
+			t.Errorf("result %d: expected status 200, got %d", i, result.StatusCode)
 		}
 	}
 }


### PR DESCRIPTION
- This change addresses the suggestions and improvements from previous PR  #19 
- Refactored the HTTP client to use context-aware requests instead of http.Get(). This avoids requests hanging forever on slow or unresponsive targets by introducing a timeout and cancellation support. The context is now propagated through RunMultiple, and the package was renamed from httpsclient to httpclient for correctness. This also makes it easier to add duration-based load testing in future.
- Modified and improved unit tests for the same.