### PR TITLE
Refactor: eliminate repetitive output formatting logic

### DIFF
--- a/cmd/result.go
+++ b/cmd/result.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/infraspecdev/goperf/internal/stats"
+)
+
+type result struct {
+	Target     string
+	Elapsed    time.Duration
+	Total      int64
+	Succeeded  int64
+	Failed     int64
+	Min        time.Duration
+	Max        time.Duration
+	Avg        time.Duration
+	P50        time.Duration
+	P90        time.Duration
+	P99        time.Duration
+	Throughput float64
+}
+
+func newResult(recorder *stats.HistogramRecorder, target string, elapsed time.Duration) *result {
+	if recorder == nil {
+		return &result{
+			Target:  target,
+			Elapsed: elapsed,
+		}
+	}
+
+	total := recorder.TotalRequests()
+	succeeded := recorder.Count()
+
+	throughput := 0.0
+	if elapsed.Seconds() > 0 {
+		throughput = float64(total) / elapsed.Seconds()
+	}
+
+	r := &result{
+		Target:     target,
+		Elapsed:    elapsed,
+		Total:      total,
+		Succeeded:  succeeded,
+		Failed:     recorder.FailedCount(),
+		Throughput: throughput,
+	}
+
+	if succeeded > 0 {
+		r.Min = recorder.Min()
+		r.Max = recorder.Max()
+		r.Avg = recorder.Avg()
+		r.P50 = recorder.Percentile(50)
+		r.P90 = recorder.Percentile(90)
+		r.P99 = recorder.Percentile(99)
+	}
+
+	return r
+}
+
+func (r *result) WriteText(w io.Writer) error {
+	_, err := fmt.Fprintf(w, `
+Target:     %s
+Duration:   %.1fs
+Requests:   %d total (%d succeeded, %d failed)
+
+`, r.Target, r.Elapsed.Seconds(), r.Total, r.Succeeded, r.Failed)
+	if err != nil {
+		return err
+	}
+
+	if r.Succeeded == 0 {
+		_, err = fmt.Fprintf(w, "Throughput: %.1f requests/sec\n", r.Throughput)
+		return err
+	}
+
+	_, err = fmt.Fprintf(w, `Latency:
+  Fastest:  %dms
+  Slowest:  %dms
+  Average:  %dms
+  p50:      %dms
+  p90:      %dms
+  p99:      %dms
+
+Throughput: %.1f requests/sec
+`,
+		r.Min.Milliseconds(), r.Max.Milliseconds(), r.Avg.Milliseconds(),
+		r.P50.Milliseconds(), r.P90.Milliseconds(), r.P99.Milliseconds(),
+		r.Throughput)
+	return err
+}

--- a/cmd/result_test.go
+++ b/cmd/result_test.go
@@ -1,0 +1,183 @@
+package cmd
+
+import (
+	"bytes"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/infraspecdev/goperf/internal/stats"
+)
+
+func newTestRecorder(latencies ...time.Duration) *stats.HistogramRecorder {
+	r := stats.NewHistogramRecorder(10 * time.Second)
+	for _, d := range latencies {
+		r.Record(d)
+	}
+	return r
+}
+
+func TestNewResult(t *testing.T) {
+	recorder := newTestRecorder(10*time.Millisecond, 20*time.Millisecond, 30*time.Millisecond)
+
+	r := newResult(recorder, "http://example.com", 1*time.Second)
+
+	if r.Target != "http://example.com" {
+		t.Errorf("expected Target %q, got %q", "http://example.com", r.Target)
+	}
+	if r.Elapsed != 1*time.Second {
+		t.Errorf("expected Elapsed %v, got %v", 1*time.Second, r.Elapsed)
+	}
+	if r.Total != 3 {
+		t.Errorf("expected Total 3, got %d", r.Total)
+	}
+	if r.Succeeded != 3 {
+		t.Errorf("expected Succeeded 3, got %d", r.Succeeded)
+	}
+	if r.Failed != 0 {
+		t.Errorf("expected Failed 0, got %d", r.Failed)
+	}
+	if r.Min != 10*time.Millisecond {
+		t.Errorf("expected Min 10ms, got %v", r.Min)
+	}
+	if r.Max != 30*time.Millisecond {
+		t.Errorf("expected Max 30ms, got %v", r.Max)
+	}
+	if r.Avg.Milliseconds() != 20 {
+		t.Errorf("expected Avg ~20ms, got %v", r.Avg)
+	}
+	if r.P50.Milliseconds() != 20 {
+		t.Errorf("expected P50 ~20ms, got %v", r.P50)
+	}
+	if r.P90.Milliseconds() != 30 {
+		t.Errorf("expected P90 ~30ms, got %v", r.P90)
+	}
+	if r.P99.Milliseconds() != 30 {
+		t.Errorf("expected P99 ~30ms, got %v", r.P99)
+	}
+	if math.Abs(r.Throughput-3.0) > 1e-9 {
+		t.Errorf("expected Throughput ~3.0, got %f", r.Throughput)
+	}
+}
+
+func TestNewResult_WithFailures(t *testing.T) {
+	recorder := newTestRecorder(10 * time.Millisecond)
+	recorder.RecordFailure()
+	recorder.RecordFailure()
+
+	r := newResult(recorder, "http://example.com", 1*time.Second)
+
+	if r.Total != 3 {
+		t.Errorf("expected Total 3, got %d", r.Total)
+	}
+	if r.Succeeded != 1 {
+		t.Errorf("expected Succeeded 1, got %d", r.Succeeded)
+	}
+	if r.Failed != 2 {
+		t.Errorf("expected Failed 2, got %d", r.Failed)
+	}
+}
+
+func TestNewResult_AllFailed(t *testing.T) {
+	recorder := stats.NewHistogramRecorder(10 * time.Second)
+	recorder.RecordFailure()
+	recorder.RecordFailure()
+
+	r := newResult(recorder, "http://example.com", 1*time.Second)
+
+	if r.Total != 2 {
+		t.Errorf("expected Total 2, got %d", r.Total)
+	}
+	if r.Succeeded != 0 {
+		t.Errorf("expected Succeeded 0, got %d", r.Succeeded)
+	}
+	if r.Min != 0 {
+		t.Errorf("expected Min 0 when no successes, got %v", r.Min)
+	}
+	if r.Max != 0 {
+		t.Errorf("expected Max 0 when no successes, got %v", r.Max)
+	}
+}
+
+func TestNewResult_ZeroElapsed(t *testing.T) {
+	recorder := newTestRecorder(10 * time.Millisecond)
+
+	r := newResult(recorder, "http://example.com", 0)
+
+	if math.Abs(r.Throughput) > 1e-9 {
+		t.Errorf("expected Throughput ~0.0 for zero elapsed, got %f", r.Throughput)
+	}
+}
+
+func TestNewResult_NilRecorder(t *testing.T) {
+	r := newResult(nil, "http://example.com", 1*time.Second)
+
+	if r.Target != "http://example.com" {
+		t.Errorf("expected Target %q, got %q", "http://example.com", r.Target)
+	}
+	if r.Elapsed != 1*time.Second {
+		t.Errorf("expected Elapsed %v, got %v", 1*time.Second, r.Elapsed)
+	}
+	if r.Total != 0 || r.Succeeded != 0 || r.Failed != 0 {
+		t.Errorf("expected zero counts, got total=%d succ=%d fail=%d", r.Total, r.Succeeded, r.Failed)
+	}
+}
+
+func TestResultWriteText(t *testing.T) {
+	recorder := newTestRecorder(10*time.Millisecond, 20*time.Millisecond, 30*time.Millisecond)
+
+	r := newResult(recorder, "http://example.com", 1*time.Second)
+
+	var buf bytes.Buffer
+	err := r.WriteText(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+
+	expected := `
+Target:     http://example.com
+Duration:   1.0s
+Requests:   3 total (3 succeeded, 0 failed)
+
+Latency:
+  Fastest:  10ms
+  Slowest:  30ms
+  Average:  20ms
+  p50:      20ms
+  p90:      30ms
+  p99:      30ms
+
+Throughput: 3.0 requests/sec
+`
+	if output != expected {
+		t.Errorf("expected output:\n%q\n\ngot:\n%q\n", expected, output)
+	}
+}
+
+func TestResultWriteText_AllFailed(t *testing.T) {
+	recorder := stats.NewHistogramRecorder(10 * time.Second)
+	recorder.RecordFailure()
+
+	r := newResult(recorder, "http://example.com", 1*time.Second)
+
+	var buf bytes.Buffer
+	err := r.WriteText(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	expected := `
+Target:     http://example.com
+Duration:   1.0s
+Requests:   1 total (0 succeeded, 1 failed)
+
+Throughput: 1.0 requests/sec
+`
+
+	if output != expected {
+		t.Errorf("expected output:\n%q\n\ngot:\n%q\n", expected, output)
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/infraspecdev/goperf/internal/httpclient"
-	"github.com/infraspecdev/goperf/internal/stats"
 	"github.com/spf13/cobra"
 )
 
@@ -74,7 +73,7 @@ func runCommandDuration(cfg httpclient.Config, out io.Writer) error {
 	recorder := httpclient.RunForDuration(ctx, cfg)
 	elapsed := time.Since(start)
 
-	return printHistogramStatistics(out, recorder, cfg.Target, elapsed)
+	return newResult(recorder, cfg.Target, elapsed).WriteText(out)
 }
 
 func runCommandMultipleConcurrent(cfg httpclient.Config, out io.Writer) error {
@@ -85,62 +84,7 @@ func runCommandMultipleConcurrent(cfg httpclient.Config, out io.Writer) error {
 	recorder := httpclient.RunMultipleConcurrent(ctx, cfg)
 	elapsed := time.Since(start)
 
-	return printHistogramStatistics(out, recorder, cfg.Target, elapsed)
-}
-
-func printHistogramStatistics(out io.Writer, recorder *stats.HistogramRecorder, target string, elapsed time.Duration) error {
-	totalReqs := recorder.TotalRequests()
-	successReqs := recorder.Count()
-	failedReqs := recorder.FailedCount()
-
-	throughput := 0.0
-	if elapsed.Seconds() > 0 {
-		throughput = float64(totalReqs) / elapsed.Seconds()
-	}
-
-	if _, err := fmt.Fprintf(out, "\nTarget:     %s\n", target); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(out, "Duration:   %.1fs\n", elapsed.Seconds()); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(out, "Requests:   %d total (%d succeeded, %d failed)\n\n", totalReqs, successReqs, failedReqs); err != nil {
-		return err
-	}
-	if successReqs == 0 {
-		if _, err := fmt.Fprintf(out, "Throughput: %.1f requests/sec\n", throughput); err != nil {
-			return err
-		}
-		return nil
-	}
-
-	if _, err := fmt.Fprintf(out, "Latency:\n"); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(out, "  Fastest:  %dms\n", recorder.Min().Milliseconds()); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(out, "  Slowest:  %dms\n", recorder.Max().Milliseconds()); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(out, "  Average:  %dms\n", recorder.Avg().Milliseconds()); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(out, "  p50:      %dms\n", recorder.Percentile(50).Milliseconds()); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(out, "  p90:      %dms\n", recorder.Percentile(90).Milliseconds()); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(out, "  p99:      %dms\n\n", recorder.Percentile(99).Milliseconds()); err != nil {
-		return err
-	}
-
-	if _, err := fmt.Fprintf(out, "Throughput: %.1f requests/sec\n", throughput); err != nil {
-		return err
-	}
-
-	return nil
+	return newResult(recorder, cfg.Target, elapsed).WriteText(out)
 }
 
 func init() {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,12 +1,8 @@
 package cmd
 
 import (
-	"bytes"
-	"strings"
 	"testing"
 	"time"
-
-	"github.com/infraspecdev/goperf/internal/stats"
 )
 
 func TestRunCmdHasNFlag(t *testing.T) {
@@ -77,29 +73,6 @@ func TestDurationFlagDefault(t *testing.T) {
 	}
 	if duration != 0 {
 		t.Errorf("expected default duration to be 0s, got %v", duration)
-	}
-}
-
-func TestPrintHistogramStatistics(t *testing.T) {
-	recorder := stats.NewHistogramRecorder(10 * time.Second)
-	recorder.Record(10 * time.Millisecond)
-	recorder.Record(20 * time.Millisecond)
-	recorder.Record(30 * time.Millisecond)
-
-	var buf bytes.Buffer
-	err := printHistogramStatistics(&buf, recorder, "http://example.com", 1*time.Second)
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	output := buf.String()
-
-	expectedSubstrings := []string{"Target:", "Duration:", "Requests:", "Latency:", "Fastest:", "Slowest:", "Average:", "p50:", "p90:", "p99:", "Throughput:"}
-	for _, sub := range expectedSubstrings {
-		if !strings.Contains(output, sub) {
-			t.Errorf("expected output to contain %q, got:\n%s", sub, output)
-		}
 	}
 }
 


### PR DESCRIPTION
This PR decouples the collection of execution statistics from standard output formatting in the CLI run command. The verbose and repetitive printHistogramStatistics function has been replaced with a dedicated Result sruct and a clean WriteText method, eliminating unnecessary error checks and laying the groundwork for future output formats (like JSON/CSV) .


- Created Result struct: Enapsulates output statistics into a structured data model to separate calculation from display logic.
- Added WriteText method: Centralizes the output formatting for terminal rendering using concise, raw string literals.
- Removed Repetitive Code: Deleted the verbose printHistogramStatistics function, eliminating 50+ lines of repeated Fprintf calls and individual error checks.
- Improved Extensibility: Sets up the architecture to easily support future output formats like JSON or CSV by simply adding new rendering methods to the struct.
