### PR TITLE
refactor: replace global cobra commands with factory functions

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,15 +4,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "goperf",
-	Short: "GoPerf is a HTTP load testing tool",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.Println("Welcome to GoPerf")
-		return nil
-	},
-}
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "goperf",
+		Short: "GoPerf is a HTTP load testing tool",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Println("Welcome to GoPerf")
+			return nil
+		},
+	}
 
-func Execute() error {
-	return rootCmd.Execute()
+	cmd.AddCommand(newRunCmd())
+	return cmd
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,15 +4,16 @@ import "testing"
 
 func TestRootCmdInitialization(t *testing.T) {
 
-	if rootCmd == nil {
-		t.Fatal("rootCmd is nil")
+	cmd := NewRootCmd()
+	if cmd == nil {
+		t.Fatal("NewRootCmd() returned nil")
 	}
 
-	if rootCmd.Use == "" {
+	if cmd.Use == "" {
 		t.Error("rootCmd Use field is empty")
 	}
 
-	if rootCmd.Use != "goperf" {
-		t.Errorf("expected rootCmd Use='goperf', got '%s'", rootCmd.Use)
+	if cmd.Use != "goperf" {
+		t.Errorf("expected rootCmd Use='goperf', got '%s'", cmd.Use)
 	}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,56 +16,68 @@ import (
 
 type runnerFunc func(ctx context.Context, cfg httpclient.Config) *stats.HistogramRecorder
 
-var runCmd = &cobra.Command{
-	Use:   "run <url>",
-	Short: "Run a load test against an HTTP endpoint",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return fmt.Errorf("missing required argument: URL")
-		}
-		return nil
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		f := cmd.Flags()
+func newRunCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run <url>",
+		Short: "Run a load test against an HTTP endpoint",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("missing required argument: URL")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			f := cmd.Flags()
 
-		concurrency, _ := f.GetInt("concurrency")
-		requests, _ := f.GetInt("requests")
-		timeout, _ := f.GetDuration("timeout")
-		duration, _ := f.GetDuration("duration")
-		method, _ := f.GetString("method")
-		body, _ := f.GetString("body")
-		headers, _ := f.GetStringArray("header")
-		method = strings.ToUpper(method)
+			concurrency, _ := f.GetInt("concurrency")
+			requests, _ := f.GetInt("requests")
+			timeout, _ := f.GetDuration("timeout")
+			duration, _ := f.GetDuration("duration")
+			method, _ := f.GetString("method")
+			body, _ := f.GetString("body")
+			headers, _ := f.GetStringArray("header")
+			method = strings.ToUpper(method)
 
-		config := RunConfig{
-			Target:      args[0],
-			Requests:    requests,
-			Concurrency: concurrency,
-			Timeout:     timeout,
-			Duration:    duration,
-			Method:      method,
-			Body:        body,
-			Headers:     headers,
-		}
+			config := RunConfig{
+				Target:      args[0],
+				Requests:    requests,
+				Concurrency: concurrency,
+				Timeout:     timeout,
+				Duration:    duration,
+				Method:      method,
+				Body:        body,
+				Headers:     headers,
+			}
 
-		err := config.Validate()
-		if err != nil {
-			return err
-		}
+			err := config.Validate()
+			if err != nil {
+				return err
+			}
 
-		u := config.ParsedTarget
+			u := config.ParsedTarget
 
-		httpCfg := config.ToHTTPConfig()
+			httpCfg := config.ToHTTPConfig()
 
-		if config.Duration > 0 {
-			fmt.Fprintf(cmd.OutOrStdout(), "Running for %v against %s with concurrency %d\n", config.Duration, u, config.Concurrency)
-			return runCommand(httpclient.RunForDuration, httpCfg, cmd.OutOrStdout())
-		}
+			if config.Duration > 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "Running for %v against %s with concurrency %d\n", config.Duration, u, config.Concurrency)
+				return runCommand(httpclient.RunForDuration, httpCfg, cmd.OutOrStdout())
+			}
 
-		fmt.Fprintf(cmd.OutOrStdout(), "Making %d requests to %v with concurrency %d\n", config.Requests, u, config.Concurrency)
+			fmt.Fprintf(cmd.OutOrStdout(), "Making %d requests to %v with concurrency %d\n", config.Requests, u, config.Concurrency)
 
-		return runCommand(httpclient.RunMultipleConcurrent, httpCfg, cmd.OutOrStdout())
-	},
+			return runCommand(httpclient.RunMultipleConcurrent, httpCfg, cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().IntP("requests", "n", 1, "Number of requests to execute")
+	cmd.Flags().DurationP("timeout", "t", 10*time.Second, "Timeout per request")
+	cmd.Flags().IntP("concurrency", "c", 1, "Number of concurrent workers")
+	cmd.Flags().DurationP("duration", "d", 0, "Duration to run the test (e.g., 10s, 1m)")
+	cmd.Flags().StringP("method", "m", "GET", "HTTP method to use")
+	cmd.Flags().StringP("body", "b", "", "Request body content")
+	cmd.Flags().StringArrayP("header", "H", []string{}, "HTTP header in 'Key: Value' format (can be repeated)")
+
+	return cmd
 }
 
 func runCommand(runner runnerFunc, cfg httpclient.Config, out io.Writer) error {
@@ -77,15 +89,4 @@ func runCommand(runner runnerFunc, cfg httpclient.Config, out io.Writer) error {
 	elapsed := time.Since(start)
 
 	return newResult(recorder, cfg.Target, elapsed).WriteText(out)
-}
-
-func init() {
-	runCmd.Flags().IntP("requests", "n", 1, "Number of requests to execute")
-	runCmd.Flags().DurationP("timeout", "t", 10*time.Second, "Timeout per request")
-	runCmd.Flags().IntP("concurrency", "c", 1, "Number of concurrent workers")
-	runCmd.Flags().DurationP("duration", "d", 0, "Duration to run the test (e.g., 10s, 1m)")
-	runCmd.Flags().StringP("method", "m", "GET", "HTTP method to use")
-	runCmd.Flags().StringP("body", "b", "", "Request body content")
-	runCmd.Flags().StringArrayP("header", "H", []string{}, "HTTP header in 'Key: Value' format (can be repeated)")
-	rootCmd.AddCommand(runCmd)
 }

--- a/cmd/run_integration_test.go
+++ b/cmd/run_integration_test.go
@@ -23,16 +23,11 @@ func TestRunCommand_RequestCountMode(t *testing.T) {
 	requests := "3"
 	concurrency := "2"
 
-	rootCmd.SetOut(&out)
-	rootCmd.SetArgs([]string{"run", server.URL, "-n", requests, "-c", concurrency})
+	cmd := NewRootCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"run", server.URL, "-n", requests, "-c", concurrency})
 
-	defer func() {
-		_ = runCmd.Flags().Set("requests", "1")
-		_ = runCmd.Flags().Set("concurrency", "1")
-		_ = runCmd.Flags().Set("timeout", "10s")
-	}()
-
-	err := rootCmd.Execute()
+	err := cmd.Execute()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -57,16 +52,11 @@ func TestRunCommand_RequestCountMode(t *testing.T) {
 func TestRunCommand_ConnectionError(t *testing.T) {
 	var out bytes.Buffer
 
-	rootCmd.SetOut(&out)
-	rootCmd.SetArgs([]string{"run", "http://127.0.0.1:12345", "-n", "2", "-c", "1"})
+	cmd := NewRootCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"run", "http://127.0.0.1:12345", "-n", "2", "-c", "1"})
 
-	defer func() {
-		_ = runCmd.Flags().Set("requests", "1")
-		_ = runCmd.Flags().Set("concurrency", "1")
-		_ = runCmd.Flags().Set("timeout", "10s")
-	}()
-
-	err := rootCmd.Execute()
+	err := cmd.Execute()
 	if err != nil {
 		t.Fatalf("expected graceful handle but got error: %v", err)
 	}
@@ -103,17 +93,12 @@ func TestRunCommand_Concurrency(t *testing.T) {
 	var out bytes.Buffer
 	requests := "10"
 	concurrency := "5"
-	rootCmd.SetOut(&out)
-	rootCmd.SetArgs([]string{"run", server.URL, "-n", requests, "-c", concurrency})
-
-	defer func() {
-		_ = runCmd.Flags().Set("requests", "1")
-		_ = runCmd.Flags().Set("concurrency", "1")
-		_ = runCmd.Flags().Set("timeout", "10s")
-	}()
+	cmd := NewRootCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"run", server.URL, "-n", requests, "-c", concurrency})
 
 	start := time.Now()
-	err := rootCmd.Execute()
+	err := cmd.Execute()
 	duration := time.Since(start)
 
 	if err != nil {
@@ -144,23 +129,12 @@ func TestRunCommand_DurationMode(t *testing.T) {
 
 	var out bytes.Buffer
 
-	_ = runCmd.Flags().Set("requests", "1")
-	runCmd.Flags().Lookup("requests").Changed = false
-
-	rootCmd.SetOut(&out)
-	rootCmd.SetArgs([]string{"run", server.URL, "--duration", "1s", "-c", "2"})
-
-	defer func() {
-		_ = runCmd.Flags().Set("requests", "1")
-		_ = runCmd.Flags().Set("concurrency", "1")
-		_ = runCmd.Flags().Set("timeout", "10s")
-		_ = runCmd.Flags().Set("duration", "0s")
-		runCmd.Flags().Lookup("duration").Changed = false
-		runCmd.Flags().Lookup("requests").Changed = false
-	}()
+	cmd := NewRootCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"run", server.URL, "--duration", "1s", "-c", "2"})
 
 	start := time.Now()
-	err := rootCmd.Execute()
+	err := cmd.Execute()
 	elapsed := time.Since(start)
 
 	if err != nil {
@@ -194,20 +168,11 @@ func TestRunCommand_MethodFlag(t *testing.T) {
 			defer server.Close()
 
 			var out bytes.Buffer
-			rootCmd.SetOut(&out)
-			rootCmd.SetArgs([]string{"run", server.URL, "-n", "1", "-m", method})
+			cmd := NewRootCmd()
+			cmd.SetOut(&out)
+			cmd.SetArgs([]string{"run", server.URL, "-n", "1", "-m", method})
 
-			defer func() {
-				_ = runCmd.Flags().Set("requests", "1")
-				_ = runCmd.Flags().Set("concurrency", "1")
-				_ = runCmd.Flags().Set("timeout", "10s")
-				_ = runCmd.Flags().Set("method", "GET")
-				_ = runCmd.Flags().Set("body", "")
-				_ = runCmd.Flags().Set("duration", "0s")
-				runCmd.Flags().Lookup("duration").Changed = false
-			}()
-
-			err := rootCmd.Execute()
+			err := cmd.Execute()
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -226,21 +191,12 @@ func TestRunCommand_MethodFlag(t *testing.T) {
 
 func TestRunCommand_InvalidMethod(t *testing.T) {
 	var out bytes.Buffer
-	rootCmd.SetOut(&out)
-	rootCmd.SetErr(&out)
-	rootCmd.SetArgs([]string{"run", "http://example.com", "-n", "1", "-m", "TRACE"})
+	cmd := NewRootCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"run", "http://example.com", "-n", "1", "-m", "TRACE"})
 
-	defer func() {
-		_ = runCmd.Flags().Set("requests", "1")
-		_ = runCmd.Flags().Set("concurrency", "1")
-		_ = runCmd.Flags().Set("timeout", "10s")
-		_ = runCmd.Flags().Set("method", "GET")
-		_ = runCmd.Flags().Set("body", "")
-		_ = runCmd.Flags().Set("duration", "0s")
-		runCmd.Flags().Lookup("duration").Changed = false
-	}()
-
-	err := rootCmd.Execute()
+	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for invalid method, got nil")
 	}
@@ -268,20 +224,11 @@ func TestRunCommand_MethodWithBody(t *testing.T) {
 			defer server.Close()
 
 			var out bytes.Buffer
-			rootCmd.SetOut(&out)
-			rootCmd.SetArgs([]string{"run", server.URL, "-n", "1", "-m", method, "-b", expectedBody})
+			cmd := NewRootCmd()
+			cmd.SetOut(&out)
+			cmd.SetArgs([]string{"run", server.URL, "-n", "1", "-m", method, "-b", expectedBody})
 
-			defer func() {
-				_ = runCmd.Flags().Set("requests", "1")
-				_ = runCmd.Flags().Set("concurrency", "1")
-				_ = runCmd.Flags().Set("timeout", "10s")
-				_ = runCmd.Flags().Set("method", "GET")
-				_ = runCmd.Flags().Set("body", "")
-				_ = runCmd.Flags().Set("duration", "0s")
-				runCmd.Flags().Lookup("duration").Changed = false
-			}()
-
-			err := rootCmd.Execute()
+			err := cmd.Execute()
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -305,22 +252,11 @@ func TestRunCommand_HeaderFlag(t *testing.T) {
 	defer server.Close()
 
 	var out bytes.Buffer
-	rootCmd.SetOut(&out)
-	rootCmd.SetArgs([]string{"run", server.URL, "-n", "1", "-H", "Authorization: Bearer test-token"})
+	cmd := NewRootCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"run", server.URL, "-n", "1", "-H", "Authorization: Bearer test-token"})
 
-	defer func() {
-		_ = runCmd.Flags().Set("requests", "1")
-		_ = runCmd.Flags().Set("concurrency", "1")
-		_ = runCmd.Flags().Set("timeout", "10s")
-		_ = runCmd.Flags().Set("method", "GET")
-		_ = runCmd.Flags().Set("body", "")
-		_ = runCmd.Flags().Set("duration", "0s")
-		runCmd.Flags().Lookup("duration").Changed = false
-		_ = runCmd.Flags().Lookup("header").Value.(interface{ Replace([]string) error }).Replace([]string{})
-		runCmd.Flags().Lookup("header").Changed = false
-	}()
-
-	err := rootCmd.Execute()
+	err := cmd.Execute()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -341,26 +277,15 @@ func TestRunCommand_MultipleHeaders(t *testing.T) {
 	defer server.Close()
 
 	var out bytes.Buffer
-	rootCmd.SetOut(&out)
-	rootCmd.SetArgs([]string{
+	cmd := NewRootCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{
 		"run", server.URL, "-n", "1",
 		"-H", "Authorization: Bearer multi-token",
 		"-H", "Content-Type: application/json",
 	})
 
-	defer func() {
-		_ = runCmd.Flags().Set("requests", "1")
-		_ = runCmd.Flags().Set("concurrency", "1")
-		_ = runCmd.Flags().Set("timeout", "10s")
-		_ = runCmd.Flags().Set("method", "GET")
-		_ = runCmd.Flags().Set("body", "")
-		_ = runCmd.Flags().Set("duration", "0s")
-		runCmd.Flags().Lookup("duration").Changed = false
-		_ = runCmd.Flags().Lookup("header").Value.(interface{ Replace([]string) error }).Replace([]string{})
-		runCmd.Flags().Lookup("header").Changed = false
-	}()
-
-	err := rootCmd.Execute()
+	err := cmd.Execute()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRunCmdHasNFlag(t *testing.T) {
-	cmd := runCmd
+	cmd := newRunCmd()
 	flag := cmd.Flags().Lookup("requests")
 	if flag == nil {
 		t.Error("Expected --n flag to exist, but it doesn't")
@@ -14,7 +14,7 @@ func TestRunCmdHasNFlag(t *testing.T) {
 }
 
 func TestNFlagDefaultValue(t *testing.T) {
-	cmd := runCmd
+	cmd := newRunCmd()
 	requests, err := cmd.Flags().GetInt("requests")
 	if err != nil {
 		t.Errorf("Error getting requests flag: %v", err)
@@ -25,7 +25,7 @@ func TestNFlagDefaultValue(t *testing.T) {
 }
 
 func TestRunCmdHasTimeoutFlag(t *testing.T) {
-	cmd := runCmd
+	cmd := newRunCmd()
 	flag := cmd.Flags().Lookup("timeout")
 	if flag == nil {
 		t.Fatal("Expected --timeout flag to exist")
@@ -33,7 +33,7 @@ func TestRunCmdHasTimeoutFlag(t *testing.T) {
 }
 
 func TestTimeoutFlagDefaultValue(t *testing.T) {
-	cmd := runCmd
+	cmd := newRunCmd()
 	timeout, err := cmd.Flags().GetDuration("timeout")
 	if err != nil {
 		t.Fatalf("Error getting timeout flag: %v", err)
@@ -44,7 +44,7 @@ func TestTimeoutFlagDefaultValue(t *testing.T) {
 }
 
 func TestConcurrencyFlagExists(t *testing.T) {
-	cmd := runCmd
+	cmd := newRunCmd()
 	flag := cmd.Flags().Lookup("concurrency")
 
 	if flag == nil {
@@ -53,7 +53,7 @@ func TestConcurrencyFlagExists(t *testing.T) {
 }
 
 func TestDurationFlagExists(t *testing.T) {
-	cmd := runCmd
+	cmd := newRunCmd()
 	flag := cmd.Flags().Lookup("duration")
 
 	if flag == nil {
@@ -66,7 +66,7 @@ func TestDurationFlagExists(t *testing.T) {
 }
 
 func TestDurationFlagDefault(t *testing.T) {
-	cmd := runCmd
+	cmd := newRunCmd()
 	duration, err := cmd.Flags().GetDuration("duration")
 	if err != nil {
 		t.Fatalf("Error getting duration flag: %v", err)
@@ -77,7 +77,7 @@ func TestDurationFlagDefault(t *testing.T) {
 }
 
 func TestMethodFlagExists(t *testing.T) {
-	cmd := runCmd
+	cmd := newRunCmd()
 	flag := cmd.Flags().Lookup("method")
 	if flag == nil {
 		t.Fatal("Expected --method flag to exist")
@@ -85,7 +85,7 @@ func TestMethodFlagExists(t *testing.T) {
 }
 
 func TestMethodFlagDefaultValue(t *testing.T) {
-	cmd := runCmd
+	cmd := newRunCmd()
 	method, err := cmd.Flags().GetString("method")
 	if err != nil {
 		t.Fatalf("Error getting method flag: %v", err)
@@ -96,7 +96,7 @@ func TestMethodFlagDefaultValue(t *testing.T) {
 }
 
 func TestBodyFlagExists(t *testing.T) {
-	cmd := runCmd
+	cmd := newRunCmd()
 	flag := cmd.Flags().Lookup("body")
 	if flag == nil {
 		t.Fatal("Expected --body flag to exist")
@@ -104,7 +104,7 @@ func TestBodyFlagExists(t *testing.T) {
 }
 
 func TestBodyFlagDefaultValue(t *testing.T) {
-	cmd := runCmd
+	cmd := newRunCmd()
 	body, err := cmd.Flags().GetString("body")
 	if err != nil {
 		t.Fatalf("Error getting body flag: %v", err)
@@ -115,7 +115,7 @@ func TestBodyFlagDefaultValue(t *testing.T) {
 }
 
 func TestHeaderFlagExists(t *testing.T) {
-	cmd := runCmd
+	cmd := newRunCmd()
 	flag := cmd.Flags().Lookup("header")
 	if flag == nil {
 		t.Fatal("Expected --header flag to exist")
@@ -126,7 +126,7 @@ func TestHeaderFlagExists(t *testing.T) {
 }
 
 func TestHeaderFlagDefaultValue(t *testing.T) {
-	cmd := runCmd
+	cmd := newRunCmd()
 	headers, err := cmd.Flags().GetStringArray("header")
 	if err != nil {
 		t.Fatalf("Error getting header flag: %v", err)

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	if err := cmd.Execute(); err != nil {
+	if err := cmd.NewRootCmd().Execute(); err != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Refactor the CLI structure to eliminate global mutable state by wrapping 
Cobra commands in factory functions (NewRootCmd and NewRunCmd). 

- Move flag registration from init() to NewRunCmd()
- Update main.go to use cmd.NewRootCmd().Execute()
- Update unit and integration tests to use command factories
- Remove manual flag reset logic in tests as each test now receives a 
  fresh command instance

This improves test isolation and eliminates potential side effects between 
test cases.
