### PR TITLE
ci(deploy): add  binary deployment workflow via WireGuard VPN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
   deploy:
     name: Deploy to Private VM
     needs: build
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
- Adds a two-stage GitHub Actions workflow (build → deploy) that compiles a ARM64 binary targeting our AWS Graviton instance.
- deploy stage is gated to push events only, preventing unintended deployments on PRs.
- Establish a WireGuard VPN tunnel before deployment.
- Uses concurrency with cancel-in-progress: false , preventing race conditions during rapid successive pushes.
- All sensitive values  are stored as repository secrets.