### PR TITLE
feat: add PR title validation

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,8 +5,9 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
-  pull-requests: write
+  pull-requests: read
   contents: read
+  statuses: write
 
 jobs:
   validate-pr-title:
@@ -31,5 +32,5 @@ jobs:
           subjectPattern: ^[a-z].+$
           subjectPatternError: |
             The subject must start with a lowercase letter.
-          wip: true
+          wip: false
           validateSingleCommit: false


### PR DESCRIPTION
Currently, there is no validation for pull request titles in the repository. This can lead to inconsistent naming, making the commit history harder to read and reducing compatibility with semantic-release.

This PR introduces a GitHub Actions workflow to enforce a consistent PR title format based on Conventional Commits.

## Changes Made
- Added a GitHub Actions workflow under `.github/workflows/`
- Triggered the workflow on `pull_request` events
- Validates PR titles against Conventional Commits format:
  - `feat:`
  - `fix:`
  - `chore:`
  - `refactor:`
  - `test:`
  - docs:' 
  - `style:`
  - `perf:`
  -  `build:`
  - `ci:`
  
- Fails the workflow if the PR title is invalid or missing a prefix

## Why This Change
- Improves commit history readability
- Enforces consistent naming conventions
- Enables compatibility with semantic-release
- Prevents invalid PR titles from being merged

## Expected Outcome
- Consistent PR title format across the repository
- Cleaner and structured commit history
- Automatic validation on every pull request

## Validation Proof

The PR title validation workflow was tested with both invalid and valid titles to ensure correct behavior.

### ❌ Invalid Title Test
- Title used: `Feat/pr title validation`
- Result: Workflow failed as expected
- Reason: Does not follow Conventional Commits format (invalid prefix and missing colon)
<img width="1920" height="1020" alt="Screenshot 2026-03-18 110926" src="https://github.com/user-attachments/assets/b4e9520c-e025-4e91-96eb-6fe156087291" />



### ✅ Valid Title Test
- Title used: `feat: add PR title validation`
- Result: Workflow passed successfully
<img width="1920" height="1020" alt="Screenshot 2026-03-18 111247" src="https://github.com/user-attachments/assets/1d95a733-9544-4585-bcfa-edf7de51b60c" />


The workflow correctly enforces the Conventional Commits format and prevents invalid PR titles from passing.