### PR TITLE
fix(cd): add retry to release binary download for CDN propagation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Download arm64 binary from release
         run: |
-          curl -sfL -o goperf-linux-arm64 \
+          curl -sfL --retry 3 --retry-delay 5 -o goperf-linux-arm64 \
             "https://github.com/${{ github.repository }}/releases/download/v${{ needs.version.outputs.version }}/goperf-linux-arm64"
 
       - name: Verify download


### PR DESCRIPTION
The deploy job's curl failed on v1.5.0 (exit code 22) because the GitHub CDN hadn't propagated the binary yet when the deploy job started immediately after the build job uploaded it.

Adds `--retry 3 --retry-delay 5` to curl so it retries up to 3 times with 5-second intervals.